### PR TITLE
Update all the URLs from '007' to 'alma'

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -22,5 +22,5 @@
         "Alma::Test" : "lib/Alma/Test.pm6",
         "Alma::Val" : "lib/Alma/Val.pm6"
     },
-    "support" : { "source"    : "git://github.com/masak/007.git" }
+    "support" : { "source"    : "git://github.com/masak/alma.git" }
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Alma [![Build Status](https://secure.travis-ci.org/masak/007.svg?branch=master)](http://travis-ci.org/masak/007)
+# Alma [![Build Status](https://secure.travis-ci.org/masak/alma.svg?branch=master)](http://travis-ci.org/masak/alma)
 
 Alma is a small language created as a testbed for Perl 6 macros. Its goal as a
 language is to inform the implementation of macros in Perl 6, by means of being
@@ -20,7 +20,7 @@ zef install alma
 ```
 
 (If you want to install from source, see [the
-documentation](http://masak.github.io/007/#installation-from-source).)
+documentation](http://masak.github.io/alma/#installation-from-source).)
 
 ### Run it
 
@@ -44,9 +44,9 @@ Alma, and then to backport that solution to Rakudo.
 
 ## Useful links
 
-* [Documentation](http://masak.github.io/007/) (🔧  under construction 🔧 )
-* [examples/ directory](https://github.com/masak/007/tree/master/examples)
-* The [Roadmap](https://github.com/masak/007/blob/master/ROADMAP.md) outlines short- and long-term goals of the Alma project
+* [Documentation](http://masak.github.io/alma/) (🔧  under construction 🔧 )
+* [examples/ directory](https://github.com/masak/alma/tree/master/examples)
+* The [Roadmap](https://github.com/masak/alma/blob/master/ROADMAP.md) outlines short- and long-term goals of the Alma project
 
 To learn more about macros:
 
@@ -58,4 +58,4 @@ To learn more about Alma:
 
 * [Double oh seven](http://strangelyconsistent.org/blog/double-oh-seven) blog post
 * [Has it been three years?](http://strangelyconsistent.org/blog/has-it-been-three-years) blog post
-* This README.md used to contain a [pastiche of the cold open in Casino Royale (2006)](https://github.com/masak/007/tree/master/documentation/bond-pastiche.md), which was entertaining for some and confusing for others
+* This README.md used to contain a [pastiche of the cold open in Casino Royale (2006)](https://github.com/masak/alma/tree/master/documentation/bond-pastiche.md), which was entertaining for some and confusing for others

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ Alma is still a v0.x.x product. There are no guarantees about backwards
 compatibility, as the need for inwards fluidity exceeds the need for
 outwards stability.
 
-The [issue queue](https://github.com/masak/007/issues), and that's still the
+The [issue queue](https://github.com/masak/alma/issues), and that's still the
 place to go to for all the nitty-gritty details about planning and tradeoffs.
 But the picture given by the issue queue is conveys no sense of priorities or
 ordering. That's what this roadmap is for.
@@ -19,27 +19,27 @@ ordering. That's what this roadmap is for.
 
   Each variable represents a *location* which can be read from and
   written to using an object-oriented API. See
-  [#214](https://github.com/masak/007/issues/214) for details. Macros
+  [#214](https://github.com/masak/alma/issues/214) for details. Macros
   that use any argument more than once need to rely on this protocol
   to avoid breaking the Single Evaluation Rule. For example, the
   `swap` macro needs this for a correct implementation. We can also
   do `postfix:<++>` and family
-  ([#122](https://github.com/masak/007/issues/122)).
+  ([#122](https://github.com/masak/alma/issues/122)).
 
 * **Get the lexical hygiene implementation in place.**
 
-  The model described in [#410](https://github.com/masak/007/issues/410)
+  The model described in [#410](https://github.com/masak/alma/issues/410)
   should be implemented. It's the only thing currently standing in the
   way of rudimentary implementations of `infix:<ff>`
-  ([#207](https://github.com/masak/007/issues/207)) and `swap`
-  ([#218](https://github.com/masak/007/issues/218)). (This item was
+  ([#207](https://github.com/masak/alma/issues/207)) and `swap`
+  ([#218](https://github.com/masak/alma/issues/218)). (This item was
   originally _first_ on this list, but has been moved to second, because
   the lexical hygiene implementation depends on the notion of locations.)
 
 * **Implement stateful macros.**
 
-  See [#312](https://github.com/masak/007/issues/312) and
-  [#313](https://github.com/masak/007/issues/313). One thing this will
+  See [#312](https://github.com/masak/alma/issues/312) and
+  [#313](https://github.com/masak/alma/issues/313). One thing this will
   immediately unlock is the ability to make `infix:<ff>` *stateful*, that
   is, the macro does not have "global" state but resets whenever the
   surrounding routine is re-entered.
@@ -47,15 +47,15 @@ ordering. That's what this roadmap is for.
 * **Implement contextual macros.**
 
   This would unlock the `each()` macro
-  ([#158](https://github.com/masak/007/issues/158)), junctions
-  ([#210](https://github.com/masak/007/issues/210)), and possibly
-  the `amb` macro ([#13](https://github.com/masak/007/issues/13)).
+  ([#158](https://github.com/masak/alma/issues/158)), junctions
+  ([#210](https://github.com/masak/alma/issues/210)), and possibly
+  the `amb` macro ([#13](https://github.com/masak/alma/issues/13)).
 
 ## `is parsed` macros
 
 After most of the rest of the roadmap was written, one issue in particular
 emerged as setting the agenda for what needs to be done short-term with Alma:
-[#194](https://github.com/masak/007/issues/194). It has proved to be important because it re-focuses Alma to get useful
+[#194](https://github.com/masak/alma/issues/194). It has proved to be important because it re-focuses Alma to get useful
 and usable macros ASAP.
 
 Most of those were mentioned above, but here are the ones that require some
@@ -65,21 +65,21 @@ uncertain time plan:
 * Reduction metaoperator, such as `[+](1, 2, 3)`. In Alma, the `[+]` would
   parse into a code-generated anonymous subroutine. This one is interesting
   for two reasons. It *really* uses closures and hygiene all-out.
-  ([#176](https://github.com/masak/007/issues/176))
+  ([#176](https://github.com/masak/alma/issues/176))
 
 * `+=` assignment operators and family. Requires the location
-  protocol. ([#152](https://github.com/masak/007/issues/152))
+  protocol. ([#152](https://github.com/masak/alma/issues/152))
 
 * `.=` mutating method call. Also requires the location protocol.
-  ([#203](https://github.com/masak/007/issues/203))
+  ([#203](https://github.com/masak/alma/issues/203))
 
 * Unbound methods. Something like `unbound .abs` to denote the longer
-  `sub (obj, ...args) { return obj.abs(...args); }`. ([#202](https://github.com/masak/007/issues/202))
+  `sub (obj, ...args) { return obj.abs(...args); }`. ([#202](https://github.com/masak/alma/issues/202))
 
 * Arrow functions. Something like `x => x * x` to denote the longer
-  `sub (x) { return x * x; }`. ([#215](https://github.com/masak/007/issues/215))
+  `sub (x) { return x * x; }`. ([#215](https://github.com/masak/alma/issues/215))
 
-* Ternary operator `?? !!`. ([#163](https://github.com/masak/007/issues/163))
+* Ternary operator `?? !!`. ([#163](https://github.com/masak/alma/issues/163))
 
 ## Pre-v1.0.0
 
@@ -92,35 +92,35 @@ The first track was the *raison d'être* for 007. The second track rounds
 Alma off as a nicer tool to work with.
 
 See also the [Reach Hacker News
-completeness](https://github.com/masak/007/issues/335) issue, which outlines
+completeness](https://github.com/masak/alma/issues/335) issue, which outlines
 some shorter-term plans.
 
 ### Macro track
 
 * The four short-term priorities all refer to macro features.
-* One focus is [quasi unquotes](https://github.com/masak/007/issues/30), a
+* One focus is [quasi unquotes](https://github.com/masak/alma/issues/30), a
   big part of making simple macros work as expected. The champion on this one
   is **masak**.
 * Make unhygienic declarations that are injected into code [actually declare
-  stuff](https://github.com/masak/007/issues/88). We can cheat majorly at this
+  stuff](https://github.com/masak/alma/issues/88). We can cheat majorly at this
   one at first, as long as it works.
-* [`is parsed`](https://github.com/masak/007/issues/#177).
+* [`is parsed`](https://github.com/masak/alma/issues/#177).
 
 ### Language track
 
 * We're in the midst of [giving the web page a big
-  facelift](https://github.com/masak/007/issues/67), including more examples.
+  facelift](https://github.com/masak/alma/issues/67), including more examples.
   The champion on this one is **masak**.
-* Implement some more [code inspection](https://github.com/masak/007/issues/222).
+* Implement some more [code inspection](https://github.com/masak/alma/issues/222).
 
 ### General cleanup that should happen before v1.0.0
 
-* [More Q node test coverage](https://github.com/masak/007/issues/52).
+* [More Q node test coverage](https://github.com/masak/alma/issues/52).
 * Various things to make the parser give better errors, like [this
-  issue](https://github.com/masak/007/issues/10) and [this
-  issue](https://github.com/masak/007/issues/48) and [this
-  issue](https://github.com/masak/007/issues/76) and [this
-  issue](https://github.com/masak/007/issues/94).
+  issue](https://github.com/masak/alma/issues/10) and [this
+  issue](https://github.com/masak/alma/issues/48) and [this
+  issue](https://github.com/masak/alma/issues/76) and [this
+  issue](https://github.com/masak/alma/issues/94).
 * Go through the code base and remove all `XXX` comments, fixing them or
   promoting them into issues.
 * [Start keeping a changelog](http://keepachangelog.com/).
@@ -131,15 +131,15 @@ As v1.0.0 rolls by, it might be good to take stock and decide a new focus for
 the next major version. However, from this vantage point, these are the
 expected areas of focus after v1.0.0.
 
-* [imports](https://github.com/masak/007/issues/53)
-* [exceptions](https://github.com/masak/007/issues/65) (already underway)
-* [class declarations](https://github.com/masak/007/issues/32) (already underway)
-* [ADTs and pattern matching](https://github.com/masak/007/issues/34)
-* [007 runtime in 007](https://github.com/masak/007/issues/51) (already underway)
-* [type checking](https://github.com/masak/007/issues/33)
-* [Qtree visitors](https://github.com/masak/007/issues/26)
-* [007 parser in 007](https://github.com/masak/007/issues/38)
-* [syntax macros](https://github.com/masak/007/issues/80)
+* [imports](https://github.com/masak/alma/issues/53)
+* [exceptions](https://github.com/masak/alma/issues/65) (already underway)
+* [class declarations](https://github.com/masak/alma/issues/32) (already underway)
+* [ADTs and pattern matching](https://github.com/masak/alma/issues/34)
+* [Alma runtime in Alma](https://github.com/masak/alma/issues/51) (already underway)
+* [type checking](https://github.com/masak/alma/issues/33)
+* [Qtree visitors](https://github.com/masak/alma/issues/26)
+* [Alma parser in Alma](https://github.com/masak/alma/issues/38)
+* [syntax macros](https://github.com/masak/alma/issues/80)
 
 Two things would be worthy enough to produce a v2.0.0 version. Either Alma being
 bootstrapping enough to have both a runtime and a parser written in itself; or

--- a/docs/index.html
+++ b/docs/index.html
@@ -47,8 +47,8 @@
       }
     </style>
   </head>
-  <body class="checksum-769a41">
-<a href="https://github.com/masak/007"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
+  <body class="checksum-51f601">
+<a href="https://github.com/masak/alma"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
 <div class="container">
 <p>This documentation has four parts:</p>
 <ul>
@@ -75,11 +75,11 @@
 </blockquote>
 <h3 id="installation-from-source">Installation (from source)</h3>
 <p>Make sure you have <a href="https://perl6.org/downloads/">Rakudo Perl 6</a> installed and in your path.</p>
-<p>Then, clone the Alma repository. (This step requires Git. There's also <a href="https://github.com/masak/007/archive/master.zip">a zip file</a>.)</p>
-<div class="sourceCode"><pre class="sourceCode sh"><code class="sourceCode bash">$ <span class="fu">git</span> clone https://github.com/masak/007.git
+<p>Then, clone the Alma repository. (This step requires Git. There's also <a href="https://github.com/masak/alma/archive/master.zip">a zip file</a>.)</p>
+<div class="sourceCode"><pre class="sourceCode sh"><code class="sourceCode bash">$ <span class="fu">git</span> clone https://github.com/masak/alma.git
 [<span class="ex">...</span>]</code></pre></div>
 <p>Finally, we need to set an environment variable <code>PERL6LIB</code>:</p>
-<div class="sourceCode"><pre class="sourceCode sh"><code class="sourceCode bash">$ <span class="bu">cd</span> 007
+<div class="sourceCode"><pre class="sourceCode sh"><code class="sourceCode bash">$ <span class="bu">cd</span> alma
 $ <span class="bu">export</span> <span class="va">PERL6LIB=$(</span><span class="bu">pwd</span><span class="va">)</span>/lib</code></pre></div>
 <blockquote class="info">
 <h4 id="perl6lib">💡 <code>PERL6LIB</code></h4>

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -43,17 +43,17 @@ Make sure you have [Rakudo Perl 6](https://perl6.org/downloads/) installed and
 in your path.
 
 Then, clone the Alma repository. (This step requires Git. There's also [a zip
-file](https://github.com/masak/007/archive/master.zip).)
+file](https://github.com/masak/alma/archive/master.zip).)
 
 ```sh
-$ git clone https://github.com/masak/007.git
+$ git clone https://github.com/masak/alma.git
 [...]
 ```
 
 Finally, we need to set an environment variable `PERL6LIB`:
 
 ```sh
-$ cd 007
+$ cd alma
 $ export PERL6LIB=$(pwd)/lib
 ```
 

--- a/documentation/generate-index-html
+++ b/documentation/generate-index-html
@@ -54,7 +54,7 @@ cat <<HEADER > $OUTFILE
     </style>
   </head>
   <body class="checksum-$CHECKSUM">
-<a href="https://github.com/masak/007"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
+<a href="https://github.com/masak/alma"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
 <div class="container">
 HEADER
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -62,7 +62,7 @@ Implements a `infix:<⊕>` operator for "bitwise xor".
 
 Showcases custom operators with `equiv` precedence. Also inadvertently
 showcases how Alma is somewhat suffering from the lack of support for low-level
-bitwise operators; see [#461](http://github.com/masak/007/issues/461).
+bitwise operators; see [#461](http://github.com/masak/alma/issues/461).
 
 ## [power.alma](/examples/power.alma)
 

--- a/feature-flags.json
+++ b/feature-flags.json
@@ -1,6 +1,6 @@
 {
     "CLASS": {
-        "issue": "https://github.com/masak/007/issues/32",
+        "issue": "https://github.com/masak/alma/issues/32",
         "tests": [
             "t/features/class.t"
         ],
@@ -15,7 +15,7 @@
         ]
     },
     "REGEX": {
-        "issue": "https://github.com/masak/007/issues/174",
+        "issue": "https://github.com/masak/alma/issues/174",
         "tests": [
             "t/features/regex.t"
         ],

--- a/lib/Alma/Parser/Actions.pm6
+++ b/lib/Alma/Parser/Actions.pm6
@@ -97,7 +97,7 @@ class Alma::Parser::Actions {
     method statement:expr ($/) {
         if $<export> {
             # For now, we're just enforcing that there's a `my` at the far left, according to the
-            # rules in https://github.com/masak/007/issues/404#issuecomment-432176865 -- we're
+            # rules in https://github.com/masak/alma/issues/404#issuecomment-432176865 -- we're
             # not actually doing anything with the information yet
 
             sub panicExportNothing() {
@@ -592,7 +592,7 @@ class Alma::Parser::Actions {
             # on the quasi.
             #
             # This is not a "nice" solution, nor a comprehensive one. In the end it's connected
-            # to the troubled musings in <https://github.com/masak/007/issues/7>, which aren't
+            # to the troubled musings in <https://github.com/masak/alma/issues/7>, which aren't
             # completely solved yet.
 
             if $qtype.value eq "Q.Statement" {

--- a/t/integration/samefringe.t
+++ b/t/integration/samefringe.t
@@ -2,7 +2,7 @@ use v6;
 use Test;
 use Alma::Test;
 
-# See https://github.com/masak/007/issues/345
+# See https://github.com/masak/alma/issues/345
 
 {
     my $program = q:to/./;


### PR DESCRIPTION
This PR tracks the rename; I believe the old links would've worked thanks to Github's ability to redirect; but better have them point to the real thing.