### PR TITLE
Add a "mention" example

### DIFF
--- a/examples/mentions.alma
+++ b/examples/mentions.alma
@@ -1,0 +1,22 @@
+BEGIN my words = ["zeroth", "first", "second", "third"];
+BEGIN my k = 0;
+
+macro mention() {
+    k = k + 1;
+    my n = k;
+    my nthWord = words[n];
+
+    return quasi {
+        say(nthWord, " mention");
+    };
+}
+
+for [{}, {}, {}] {
+    mention();        # first mention
+    mention();        # second mention
+}
+
+mention();            # third mention
+mention();            # fourth mention
+
+say(k);               # 4


### PR DESCRIPTION
This file is a contrived example, meant to highlight the fact that, even though eight lines
of code are printed, only four macro calls are made.

I have no idea whether this will work or not in the current implementation. It should, and
I know of no reason why it would not, but I haven't tried it. A test needs to be added
before this can be merged.